### PR TITLE
#19: Provide JPMS descriptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/**
 .idea/**
 *.iml
 **/dependency-reduced-pom.xml
+/target/

--- a/api-only/src/main/java/module-info.java
+++ b/api-only/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 module gmbal {
     requires java.logging;
-    requires transitive java.management;
+    requires transitive org.glassfish.external.management.api;
 
     exports org.glassfish.gmbal;
     exports org.glassfish.pfl.tf.timer.spi;

--- a/api-only/src/main/java/module-info.java
+++ b/api-only/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+module gmbal {
+    requires java.logging;
+    requires transitive java.management;
+
+    exports org.glassfish.gmbal;
+    exports org.glassfish.pfl.tf.timer.spi;
+}

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -83,7 +83,7 @@
                         <configuration>
                             <includeArtifactIds>gmbal-api-only</includeArtifactIds>
                             <classifier>sources</classifier>
-                            <excludes>**/pfl/**,META-INF/**</excludes>
+                            <excludes>module-info.*,**/pfl/**,META-INF/**</excludes>
                             <outputDirectory>${project.build.directory}/generated-sources/api</outputDirectory>
                         </configuration>
                     </execution>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -109,6 +109,22 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xlint:all</arg>
+                                <arg>--add-reads</arg>
+                                <arg>gmbal=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <executions>
@@ -134,6 +150,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>META-INF/jpms.args</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/impl/src/main/java/module-info.java
+++ b/impl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 module gmbal {
     requires java.logging;
-    requires transitive java.management;
+    requires transitive org.glassfish.external.management.api;
 
     exports org.glassfish.gmbal;
     exports org.glassfish.gmbal.impl.trace;

--- a/impl/src/main/java/module-info.java
+++ b/impl/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+module gmbal {
+    requires java.logging;
+    requires transitive java.management;
+
+    exports org.glassfish.gmbal;
+    exports org.glassfish.gmbal.impl.trace;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.5</version>
+        <version>1.0.6</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.glassfish.gmbal</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     </mailingLists>
 
     <properties>
-        <jdkVersion>1.8</jdkVersion>
+        <jdkVersion>8</jdkVersion>
         <pfl.version>4.1.0</pfl.version>
         <gmbal.commons.version>3.2.2</gmbal.commons.version>
         <legal.doc.source>${project.basedir}/..</legal.doc.source>
@@ -148,16 +148,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
-                    <configuration>
-                        <source>${jdkVersion}</source>
-                        <target>${jdkVersion}</target>
-                    </configuration>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.0</version>
+                    <version>4.2.1</version>
                 </plugin>
                 <!-- override default "built-by" entry, which points to a developer's user id -->
                 <plugin>
@@ -167,10 +163,6 @@
                     <configuration>
                         <archive>
                             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
-                            <manifestEntries>
-                                <Built-By>Oracle</Built-By>
-                                <Automatic-Module-Name>gmbal</Automatic-Module-Name>
-                            </manifestEntries>
                         </archive>
                     </configuration>
                 </plugin>
@@ -192,10 +184,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.1</version>
                     <configuration>
-                        <detectJavaApiLink>false</detectJavaApiLink>
-                        <detectOfflineLinks>false</detectOfflineLinks>
+                        <release>${jdkVersion}</release>
+                        <sourceFileExcludes>
+                            <sourceFileExclude>module-info.java</sourceFileExclude>
+                        </sourceFileExcludes>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -207,6 +201,38 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>9</release>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-Xlint:all</arg>
+                                <arg>--add-reads</arg>
+                                <arg>gmbal=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>${jdkVersion}</release>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- prevent the site plugin from deploying to the scm url -->
             <plugin>
                 <artifactId>maven-site-plugin</artifactId>
@@ -292,7 +318,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
                 <reportSets>
                     <reportSet>
                         <id>javadoc-only</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -84,7 +84,7 @@
     <properties>
         <jdkVersion>8</jdkVersion>
         <pfl.version>4.1.0</pfl.version>
-        <gmbal.commons.version>3.2.2</gmbal.commons.version>
+        <gmbal.commons.version>3.2.3</gmbal.commons.version>
         <legal.doc.source>${project.basedir}/..</legal.doc.source>
     </properties>
 
@@ -214,8 +214,6 @@
                         <configuration>
                             <compilerArgs>
                                 <arg>-Xlint:all</arg>
-                                <arg>--add-reads</arg>
-                                <arg>gmbal=ALL-UNNAMED</arg>
                             </compilerArgs>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Fixes #19 

Changes are built on top of PR #16, JPMS descriptor will have to be updated once new version of management-api containing https://github.com/eclipse-ee4j/orb-gmbal-commons/pull/18 (or its variant) becomes available.