### PR TITLE
#22 Add escape hatch for fatal exception on latest JDK versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,17 @@ build/**
 *.iml
 **/dependency-reduced-pom.xml
 /target/
+*.ipr
+*.iml
+*.iws
+*.swp
+*~
+*.output
+*.class
+target/
+.idea
+nbactions.xml
+nb-configuration.xml
+.classpath
+.project
+.settings/

--- a/api-only/pom.xml
+++ b/api-only/pom.xml
@@ -16,13 +16,13 @@
     <parent>
         <groupId>org.glassfish.gmbal</groupId>
         <artifactId>gmbal-project</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish.gmbal</groupId>
     <artifactId>gmbal-api-only</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.3-SNAPSHOT</version>
 
     <name>GMBAL (API only)</name>
     <description>GlassFish MBean Annotation Library (API only)</description>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -16,12 +16,12 @@
     <parent>
         <groupId>org.glassfish.gmbal</groupId>
         <artifactId>gmbal-project</artifactId>
-        <version>4.0.1-SNAPSHOT</version>
+        <version>4.0.3-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.gmbal</groupId>
     <artifactId>gmbal</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.3-SNAPSHOT</version>
 
     <name>GMBAL (Implementation)</name>
     <description>GlassFish MBean Annotation Library (Implementation)</description>

--- a/impl/src/main/java/org/glassfish/gmbal/typelib/TypeEvaluator.java
+++ b/impl/src/main/java/org/glassfish/gmbal/typelib/TypeEvaluator.java
@@ -10,33 +10,34 @@
 
 package org.glassfish.gmbal.typelib;
 
+import static java.lang.Boolean.FALSE;
+import static java.lang.reflect.Modifier.PUBLIC;
+
 import java.lang.reflect.Field;
-import java.security.PrivilegedActionException;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static java.lang.reflect.Modifier.* ;
-
-import java.lang.reflect.Type ;
 import java.lang.reflect.GenericArrayType ;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.WildcardType ;
 import java.lang.reflect.ParameterizedType ;
+import java.lang.reflect.Type ;
 import java.lang.reflect.TypeVariable ;
+import java.lang.reflect.WildcardType ;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.WeakHashMap;
+
 import javax.management.ObjectName;
+
 import org.glassfish.gmbal.impl.trace.TraceTypelib;
 import org.glassfish.gmbal.impl.trace.TraceTypelibEval;
 import org.glassfish.pfl.basic.algorithm.Algorithms;
@@ -316,11 +317,13 @@ public class TypeEvaluator {
                 Type[] bounds = tv.getBounds() ;
                 if (bounds.length > 0) {
                     if (bounds.length > 1) {
-                        throw Exceptions.self
-                            .multipleUpperBoundsNotSupported( tv ) ;
-                    } else {
-                        type = bounds[0] ;
-                    }
+                        if (!Boolean.valueOf(System.getProperty("org.glassfish.gmbal.no.multipleUpperBoundsException"))) {
+                            throw Exceptions.self
+                                .multipleUpperBoundsNotSupported( tv ) ;
+                        }
+                    } 
+                    
+                    type = bounds[0] ;
                 } else {
                     type = Object.class ;
                 }
@@ -601,8 +604,10 @@ public class TypeEvaluator {
                 List<Type> ub = Arrays.asList( wt.getUpperBounds() ) ;
                 if (ub.size() > 0) {
                     if (ub.size() > 1) {
-                        throw Exceptions.self.multipleUpperBoundsNotSupported(
-                            wt) ;
+                        if (!Boolean.valueOf(System.getProperty("org.glassfish.gmbal.no.multipleUpperBoundsException"))) {
+                            throw Exceptions.self.multipleUpperBoundsNotSupported(
+                                wt) ;
+                        }
                     }
 
                     result = evaluateType( ub.get(0) ) ;
@@ -628,8 +633,10 @@ public class TypeEvaluator {
                     Type[] bounds = tvar.getBounds() ;
                     if (bounds.length > 0) {
                         if (bounds.length > 1) {
-                            throw Exceptions.self
-                                .multipleUpperBoundsNotSupported( tvar ) ;
+                            if (!Boolean.valueOf(System.getProperty("org.glassfish.gmbal.no.multipleUpperBoundsException"))) {
+                                throw Exceptions.self
+                                    .multipleUpperBoundsNotSupported( tvar ) ;
+                            }
                         }
 
                         result = evaluateType( bounds[0] ) ;

--- a/impl/src/main/java/org/glassfish/gmbal/typelib/TypeEvaluator.java
+++ b/impl/src/main/java/org/glassfish/gmbal/typelib/TypeEvaluator.java
@@ -55,6 +55,18 @@ import org.glassfish.pfl.tf.spi.annotation.InfoMethod;
 @TraceTypelibEval
 public class TypeEvaluator {
     
+    /**
+     * For ORB compatibility with JDK11+ JDKs see https://github.com/eclipse-ee4j/orb-gmbal/issues/22
+     * 
+     * <p>
+     * In short, the ORB references com.sun.corba.ee.spi.orb.ORB, which references com.sun.corba.ee.impl.corba.TypeCodeFactory
+     * which eventually references com.sun.corba.ee.spi.legacy.connection.Connection.getSocket and java.net.Socket.checkPermission(java.net.SocketImpl).
+     * 
+     * <p>
+     * Now SocketImpl contains a method "&lt;S extends SocketImpl & PlatformSocketImpl> S createPlatformSocketImpl", which causes the ORB to crash 
+     * completely. Setting a system property with this string ignores the fact GMBAL doesn't support multiple upper bounds.
+     * 
+     */
     private static final String ORG_GLASSFISH_GMBAL_NO_MULTIPLE_UPPER_BOUNDS_EXCEPTION = "org.glassfish.gmbal.no.multipleUpperBoundsException";
     
     private TypeEvaluator() {}

--- a/impl/src/main/java/org/glassfish/gmbal/typelib/TypeEvaluator.java
+++ b/impl/src/main/java/org/glassfish/gmbal/typelib/TypeEvaluator.java
@@ -10,7 +10,6 @@
 
 package org.glassfish.gmbal.typelib;
 
-import static java.lang.Boolean.FALSE;
 import static java.lang.reflect.Modifier.PUBLIC;
 
 import java.lang.reflect.Field;
@@ -55,6 +54,9 @@ import org.glassfish.pfl.tf.spi.annotation.InfoMethod;
 @TraceTypelib
 @TraceTypelibEval
 public class TypeEvaluator {
+    
+    private static final String ORG_GLASSFISH_GMBAL_NO_MULTIPLE_UPPER_BOUNDS_EXCEPTION = "org.glassfish.gmbal.no.multipleUpperBoundsException";
+    
     private TypeEvaluator() {}
 
     private static Map<Class<?>,EvaluatedType> immutableTypes =
@@ -307,6 +309,7 @@ public class TypeEvaluator {
     // (and each instance of Enum MUST evaluate to the same ECD, or we get
     // infinite recursion).
     private static class PartialDefinitions {
+        
         private Map<Pair<Class<?>,List<Type>>,EvaluatedType> table =
             new HashMap<Pair<Class<?>,List<Type>>,EvaluatedType>() ;
 
@@ -317,7 +320,7 @@ public class TypeEvaluator {
                 Type[] bounds = tv.getBounds() ;
                 if (bounds.length > 0) {
                     if (bounds.length > 1) {
-                        if (!Boolean.valueOf(System.getProperty("org.glassfish.gmbal.no.multipleUpperBoundsException"))) {
+                        if (!Boolean.valueOf(System.getProperty(ORG_GLASSFISH_GMBAL_NO_MULTIPLE_UPPER_BOUNDS_EXCEPTION))) {
                             throw Exceptions.self
                                 .multipleUpperBoundsNotSupported( tv ) ;
                         }
@@ -604,7 +607,7 @@ public class TypeEvaluator {
                 List<Type> ub = Arrays.asList( wt.getUpperBounds() ) ;
                 if (ub.size() > 0) {
                     if (ub.size() > 1) {
-                        if (!Boolean.valueOf(System.getProperty("org.glassfish.gmbal.no.multipleUpperBoundsException"))) {
+                        if (!Boolean.valueOf(System.getProperty(ORG_GLASSFISH_GMBAL_NO_MULTIPLE_UPPER_BOUNDS_EXCEPTION))) {
                             throw Exceptions.self.multipleUpperBoundsNotSupported(
                                 wt) ;
                         }
@@ -633,7 +636,7 @@ public class TypeEvaluator {
                     Type[] bounds = tvar.getBounds() ;
                     if (bounds.length > 0) {
                         if (bounds.length > 1) {
-                            if (!Boolean.valueOf(System.getProperty("org.glassfish.gmbal.no.multipleUpperBoundsException"))) {
+                            if (!Boolean.valueOf(System.getProperty(ORG_GLASSFISH_GMBAL_NO_MULTIPLE_UPPER_BOUNDS_EXCEPTION))) {
                                 throw Exceptions.self
                                     .multipleUpperBoundsNotSupported( tvar ) ;
                             }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.glassfish.gmbal</groupId>
     <artifactId>gmbal-project</artifactId>
-    <version>4.0.1-SNAPSHOT</version>
+    <version>4.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GMBAL</name>
@@ -83,7 +83,7 @@
 
     <properties>
         <jdkVersion>8</jdkVersion>
-        <pfl.version>4.1.0</pfl.version>
+        <pfl.version>4.1.2</pfl.version>
         <gmbal.commons.version>3.2.3</gmbal.commons.version>
         <legal.doc.source>${project.basedir}/..</legal.doc.source>
     </properties>
@@ -123,7 +123,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13.2</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -154,7 +154,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <version>5.1.2</version>
                 </plugin>
                 <!-- override default "built-by" entry, which points to a developer's user id -->
                 <plugin>


### PR DESCRIPTION
Note this fatal exception has been lurking in the code all along, but it
seems like in ~14 years nobody ever uses GMBAL on a code base where a
method had a generic type with two bounds.

Also updated .gitignore and pom.xml

Signed-off-by: arjantijms <arjan.tijms@gmail.com>