### PR TITLE
Reviewed and fixed osgi values in manifest and module-info

### DIFF
--- a/api-only/pom.xml
+++ b/api-only/pom.xml
@@ -42,9 +42,8 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                        <Bundle-Name>${project.name}</Bundle-Name>
-                        <Bundle-Version>${project.version}</Bundle-Version>
                         <Export-Package>org.glassfish.gmbal,org.glassfish.pfl.tf.timer.spi</Export-Package>
+                        <Private-Package>org.glassfish.gmbal.util</Private-Package>
                     </instructions>
                 </configuration>
                 <executions>
@@ -55,8 +54,8 @@
                     </execution>
                 </executions>
             </plugin>
-            
-            <plugin> 
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -126,27 +126,20 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package>org.glassfish.gmbal.impl</Export-Package>
+                        <Private-Package>
+                            org.glassfish.gmbal.main, org.glassfish.gmbal.impl.trace, org.glassfish.gmbal.typelib
+                        </Private-Package>
+                    </instructions>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>generate-manifest</id>
                         <goals>
                             <goal>manifest</goal>
                         </goals>
-                        <configuration>
-                            <instructions>
-                                <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-                                <Bundle-Name>${project.name}</Bundle-Name>
-                                <Bundle-Version>${project.version}</Bundle-Version>
-                                <Export-Package>org.glassfish.gmbal, org.glassfish.gmbal.impl.trace</Export-Package>
-                                <Private-Package>
-                                    org.glassfish.gmbal.util, org.glassfish.gmbal.impl, org.glassfish.gmbal.typelib
-                                </Private-Package>
-                                <!-- Include-Resource>
-                                        TODO: Use PFL ExceptionResourceGenerator to automatically generate resource files
-                                        under src/main/resources.  See build.xml for sample usage.
-                                </Include-Resource -->
-                            </instructions>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/impl/src/main/java/module-info.java
+++ b/impl/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -12,6 +13,5 @@ module gmbal {
     requires java.logging;
     requires transitive org.glassfish.external.management.api;
 
-    exports org.glassfish.gmbal;
-    exports org.glassfish.gmbal.impl.trace;
+    exports org.glassfish.gmbal.impl;
 }


### PR DESCRIPTION
* This PR fixes issue discovered when I was working on https://github.com/eclipse-ee4j/glassfish/pull/25183 where I introduced another piece of JPMS. The impl package was missing in module-info, however it is explicitly used.
* see https://github.com/eclipse-ee4j/orb-gmbal/tree/master/impl/src/main/java/org/glassfish/gmbal - there are three subpackages: impl, main, typelib - exporting just `org.glassfish.gmbal` in fact doesn't export anything (`impl.trace` is ok but I don't think we need to export it).
* similar problem is with osgi
  * Felix plugin does better job with defaults; by default it would not export just `impl` and `internal` packages if I remember well.

**Change** in imports+exports: `4.0.4` instead of `4.0.4.SNAPSHOT`, so it can be locally tested in snapshots together with GlassFish as this is default and consistent behavior.

Packages:
* API: 
   * `org.glassfish.gmbal` - no change, exported
   * `org.glassfish.gmbal.util` - internal package used just in local `ManagedObjectManagerFactory`, **change**: both export  and import stopped (just module-info had this issue).
   * `org.glassfish.pfl.tf.timer.spi` - no change, exported
 
* IMPL
   * The only place I have found its usage is the API module.
   * `org.glassfish.gmbal `- **change**: contains just subpackages, so removed from manifest.  
   * `org.glassfish.gmbal.impl `- **change**: now it is exported in `module-info` as it is explicitly used by API (reflection). Changed also `uses` in manifest (generated by Felix).
   * `org.glassfish.gmbal.impl.trace` - **change**: not used outside IMPL -> not exported, not imported
   * `org.glassfish.gmbal.main` - no change, not exported
   * `org.glassfish.gmbal.typelib` - no change, not exported
