### PR TITLE
Release of 4.1.0

### DIFF
--- a/api-only/pom.xml
+++ b/api-only/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.gmbal</groupId>
         <artifactId>gmbal-project</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/api-only/pom.xml
+++ b/api-only/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.gmbal</groupId>
         <artifactId>gmbal-project</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.gmbal</groupId>
         <artifactId>gmbal-project</artifactId>
-        <version>4.1.0</version>
+        <version>4.1.1-SNAPSHOT</version>
     </parent>
 
     <groupId>org.glassfish.gmbal</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.glassfish.gmbal</groupId>
         <artifactId>gmbal-project</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>4.1.0</version>
     </parent>
 
     <groupId>org.glassfish.gmbal</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.glassfish.gmbal</groupId>
     <artifactId>gmbal-project</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.1.0</version>
     <packaging>pom</packaging>
 
     <name>GMBAL</name>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.glassfish.gmbal</groupId>
     <artifactId>gmbal-project</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GMBAL</name>


### PR DESCRIPTION
Recreated https://github.com/eclipse-ee4j/orb-gmbal/pull/54 which was closed automatically after restaging.
